### PR TITLE
[control plane] Fix ingress rule in README

### DIFF
--- a/charts/control-plane/README.md
+++ b/charts/control-plane/README.md
@@ -47,7 +47,7 @@ ingress:
   enabled: true
   className: nginx
   hosts:
-    - host: cp.nats.io
+    - cp.nats.io
   tlsSecretName: ingress-tls
 ```
 


### PR DESCRIPTION
Prior to this change the README had the ingress hosts as a list of maps instead of a list of values. This changes the ingress hosts to a list of values in the README.