### PR TITLE
Control Plane | Explicitly Define the Cluster Port

### DIFF
--- a/charts/control-plane/files/deployment/syn-cp-container.yaml
+++ b/charts/control-plane/files/deployment/syn-cp-container.yaml
@@ -13,6 +13,8 @@ env:
 {{- end }}
 
 ports:
+- name: cluster
+  containerPort: 6222
 - name: http
   containerPort: {{ .Values.config.server.httpPort }}
 {{- if .config.server.tls }}


### PR DESCRIPTION
- Explicitly define the cluster (6222) port on the SCP container
  - When running in HA pods communicate to each other over it.
  - https://docs.synadia.com/platform/control-plane/architecture#security